### PR TITLE
fixing the slow pasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cd archethic-cli
 go build .
 ```
 
-Please note that you would need to install a clipboard utility if you want to be able to paste text/code (like xsel, xclip, wl-clipboard or Termux).
+On UNIX system, please note that you would need to install a clipboard utility if you want to be able to paste text/code (like xsel, xclip, wl-clipboard or Termux).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ cd archethic-cli
 go build .
 ```
 
+Please note that you would need to install a clipboard utility if you want to be able to paste text/code (like xsel, xclip, wl-clipboard or Termux).
+
 ## Usage
 
 By default the CLI works as TUI (terminal user interface) application allowing the application to be interactive. 

--- a/tui/keychaincreatetransactionui/contentmodel.go
+++ b/tui/keychaincreatetransactionui/contentmodel.go
@@ -40,6 +40,18 @@ func (m ContentModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 
+		// this is used to get a faster paste
+		case "ctrl+v":
+
+			if !m.contentTextAreaInput.Focused() {
+				m.contentTextAreaInput.Focus()
+			}
+			newText := textarea.Paste()
+			m.contentTextAreaInput, _ = m.contentTextAreaInput.Update(newText)
+			return m, func() tea.Msg {
+				return UpdateSmartContract{Code: m.contentTextAreaInput.Value()}
+			}
+
 		default:
 
 			if !m.contentTextAreaInput.Focused() {

--- a/tui/keychaincreatetransactionui/contentmodel.go
+++ b/tui/keychaincreatetransactionui/contentmodel.go
@@ -26,6 +26,8 @@ func NewContentModel() ContentModel {
 	m := ContentModel{}
 	m.contentTextAreaInput = textarea.New()
 	m.contentTextAreaInput.CharLimit = 0
+	m.contentTextAreaInput.MaxHeight = 0
+	m.contentTextAreaInput.SetHeight(20)
 	m.contentTextAreaInput.SetWidth(150)
 
 	return m
@@ -54,7 +56,17 @@ func (m ContentModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return updateContentValue(&m, msg)
 			}
 
+		case "ctrl+v", "ctrl+shift+v":
+			if !m.contentTextAreaInput.Focused() {
+				m.contentTextAreaInput.Focus()
+				m.focusInput = 0
+			}
+
+			newText := textarea.Paste()
+			return updateContentValue(&m, newText)
+
 		case "enter":
+			// Paste button
 			if m.focusInput == 1 {
 				if !m.contentTextAreaInput.Focused() {
 					m.contentTextAreaInput.Focus()

--- a/tui/keychaincreatetransactionui/model.go
+++ b/tui/keychaincreatetransactionui/model.go
@@ -277,7 +277,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if (m.activeTab == CONTENT_TAB && !m.contentModel.contentTextAreaInput.Focused()) ||
 				(m.activeTab == SMART_CONTRACT_TAB && !m.smartContractModel.smartContractTextAreaInput.Focused()) ||
 				(m.activeTab != CONTENT_TAB && m.activeTab != SMART_CONTRACT_TAB) {
-				m.activeTab = createTransactionTab(min(int(m.activeTab)+1, len(m.Tabs)-1))
+				m.activeTab = getNewTab(&m, int(m.activeTab)+1)
 				cmds = focusOnTab(&m)
 			} else if m.activeTab == CONTENT_TAB {
 				w, cmds := m.contentModel.Update(msg)
@@ -294,7 +294,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if (m.activeTab == CONTENT_TAB && !m.contentModel.contentTextAreaInput.Focused()) ||
 				(m.activeTab == SMART_CONTRACT_TAB && !m.smartContractModel.smartContractTextAreaInput.Focused()) ||
 				(m.activeTab != CONTENT_TAB && m.activeTab != SMART_CONTRACT_TAB) {
-				m.activeTab = createTransactionTab(max(int(m.activeTab)-1, 0))
+				m.activeTab = getNewTab(&m, int(m.activeTab)-1)
 				cmds = focusOnTab(&m)
 			} else if m.activeTab == CONTENT_TAB {
 				w, cmds := m.contentModel.Update(msg)
@@ -351,6 +351,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(cmds...)
 }
 
+func getNewTab(m *Model, tabNb int) createTransactionTab {
+	switch {
+	case tabNb > len(m.Tabs)-1:
+		return 0
+	case tabNb < 0:
+		return createTransactionTab(len(m.Tabs) - 1)
+	default:
+		return createTransactionTab(tabNb)
+	}
+}
 func focusOnTab(m *Model) []tea.Cmd {
 	var cmds []tea.Cmd
 	switch m.activeTab {

--- a/tui/keychaincreatetransactionui/recipientsmodel.go
+++ b/tui/keychaincreatetransactionui/recipientsmodel.go
@@ -48,9 +48,10 @@ func (m RecipientsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "enter":
 
 			if m.focusInput == 1 || m.focusInput == 0 {
+				m.feedback = ""
 				recipientHex := m.recipientsInput.Value()
 				recipient, err := hex.DecodeString(recipientHex)
-				if err != nil {
+				if err != nil || recipientHex == "" {
 					m.feedback = "Invalid recipient address"
 					return m, nil
 				}

--- a/tui/keychaincreatetransactionui/smartcontractmodel.go
+++ b/tui/keychaincreatetransactionui/smartcontractmodel.go
@@ -26,6 +26,8 @@ func NewSmartContractModel() SmartContractModel {
 	m := SmartContractModel{}
 	m.smartContractTextAreaInput = textarea.New()
 	m.smartContractTextAreaInput.CharLimit = 0
+	m.smartContractTextAreaInput.MaxHeight = 0
+	m.smartContractTextAreaInput.SetHeight(20)
 	m.smartContractTextAreaInput.SetWidth(150)
 	return m
 }
@@ -52,7 +54,16 @@ func (m SmartContractModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return updateSmartContractValue(&m, msg)
 			}
 
+		case "ctrl+v", "ctrl+shift+v":
+
+			if !m.smartContractTextAreaInput.Focused() {
+				m.smartContractTextAreaInput.Focus()
+				m.focusInput = 0
+			}
+			newText := textarea.Paste()
+			return updateSmartContractValue(&m, newText)
 		case "enter":
+			// Paste button
 			if m.focusInput == 1 {
 				if !m.smartContractTextAreaInput.Focused() {
 					m.smartContractTextAreaInput.Focus()

--- a/tui/keychaincreatetransactionui/smartcontractmodel.go
+++ b/tui/keychaincreatetransactionui/smartcontractmodel.go
@@ -37,6 +37,17 @@ func (m SmartContractModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.smartContractTextAreaInput.Blur()
 			}
 			return m, nil
+		// this is used to get a faster paste
+		case "ctrl+v":
+
+			if !m.smartContractTextAreaInput.Focused() {
+				m.smartContractTextAreaInput.Focus()
+			}
+			newText := textarea.Paste()
+			m.smartContractTextAreaInput, _ = m.smartContractTextAreaInput.Update(newText)
+			return m, func() tea.Msg {
+				return UpdateSmartContract{Code: m.smartContractTextAreaInput.Value()}
+			}
 		default:
 
 			if !m.smartContractTextAreaInput.Focused() {


### PR DESCRIPTION
This PR: 
- adds a paste button to allow "fast pasting" (otherwise it's pasting character by character)
- avoids insertion of an empty recipient
- remove the limit of 99 lines in the textareas (for content and smartcontract)
- increases the height of the textareas (for content and smartcontract)
- sets a more intuitive way to navigate within tabs (when creating a transaction)