### PR TITLE
Fix transaction version when using keychain

### DIFF
--- a/tui/tuiutils/utils.go
+++ b/tui/tuiutils/utils.go
@@ -290,8 +290,6 @@ func buildKeychainTransaction(seed []byte, client *archethic.APIClient, transact
 		return err
 	}
 
-	transaction.Version = uint32(keychain.Version)
-
 	genesisAddress, err := keychain.DeriveAddress(serviceName, 0)
 	if err != nil {
 		return err


### PR DESCRIPTION
Transaction version was set with keychain version which is not correct.
Removed this assignation to use the default Archethic sdk version