### PR TITLE
Remove index from derivation path

### DIFF
--- a/tui/keychainmanagementui/model.go
+++ b/tui/keychainmanagementui/model.go
@@ -277,7 +277,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// set a default derivation path
 			if m.focusIndex == len(m.inputs)+6+len(m.serviceNames)+1 {
 				serviceName := m.newServiceInputs[0].Value()
-				derivationPath := "m/650'/" + serviceName + msg.String() + "/0"
+				derivationPath := "m/650'/" + serviceName + msg.String()
 				m.newServiceInputs[1].SetValue(derivationPath)
 			}
 		}

--- a/tui/tuiutils/utils.go
+++ b/tui/tuiutils/utils.go
@@ -68,7 +68,7 @@ func CreateKeychain(url string, accessSeed []byte) (string, string, string, stri
 	rand.Read(randomSeed)
 
 	keychain := archethic.NewKeychain(randomSeed)
-	keychain.AddService("uco", "m/650'/0/0", archethic.ED25519, archethic.SHA256)
+	keychain.AddService("uco", "m/650'/0", archethic.ED25519, archethic.SHA256)
 	keychain.AddAuthorizedPublicKey(publicKey)
 
 	accessAddress, err := archethic.DeriveAddress(accessSeed, 1, archethic.ED25519, archethic.SHA256)


### PR DESCRIPTION
Remove the index from the derivationpath because it was not matching how the node work.


**before**
hello: m/650'/hello/0
uco: m/650'/0/0 (I don't know why the uco service is name 0 but that does not matter)

**after**
<img width="1028" alt="Capture d’écran 2024-08-01 à 14 37 22" src="https://github.com/user-attachments/assets/653638f8-477b-40ee-b791-3ba68f3d5cc2">


